### PR TITLE
feat(devices): Implement device detail pages with history tracking

### DIFF
--- a/api-service/app/main.py
+++ b/api-service/app/main.py
@@ -20,9 +20,13 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
+        "http://localhost:3001",
         "http://localhost:8000",
+        "http://localhost:8001",
         "http://127.0.0.1:3000",
+        "http://127.0.0.1:3001",
         "http://127.0.0.1:8000",
+        "http://127.0.0.1:8001",
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/api-service/app/routers/network.py
+++ b/api-service/app/routers/network.py
@@ -85,11 +85,7 @@ async def get_device_history(device_id: str, limit: int = 100):
         mac = ":".join([device_id[i : i + 2] for i in range(0, len(device_id), 2)])
         history = network_monitor.get_device_history(mac, limit)
 
-        if not history:
-            raise HTTPException(
-                status_code=404, detail=f"No history found for device {device_id}"
-            )
-
+        # Return empty history if none exists yet (device might be new)
         return {"device_id": device_id, "history": history}
     except HTTPException:
         raise

--- a/api-service/app/services/network_monitor.py
+++ b/api-service/app/services/network_monitor.py
@@ -476,6 +476,20 @@ class NetworkMonitorService:
                     )
                     devices.append(device)
 
+                    # Track device history for trend analysis (keep last 100 snapshots)
+                    if mac not in self.device_history:
+                        self.device_history[mac] = deque(maxlen=100)
+
+                    history_snapshot = {
+                        "timestamp": datetime.now(),
+                        "status": "online",
+                        "latency": latency,
+                        "packet_loss": packet_loss,
+                        "connection_quality": connection_quality,
+                        "ip": ip,
+                    }
+                    self.device_history[mac].append(history_snapshot)
+
                     # Evaluate device for alerts
                     alerts = self.alert_manager.evaluate_device(device)
                     for alert in alerts:
@@ -683,6 +697,47 @@ class NetworkMonitorService:
                 )
 
         return data
+
+    def get_device_history(self, mac: str, limit: int = 100) -> List[Dict[str, Any]]:
+        """
+        Get historical data for a specific device
+        Returns list of snapshots with timestamp, status, latency, packet_loss, etc.
+        """
+        if mac not in self.device_history:
+            return []
+
+        # Convert deque to list and limit results
+        history = list(self.device_history[mac])
+        if limit:
+            history = history[-limit:]
+
+        # Convert to serializable format
+        return [
+            {
+                "timestamp": snapshot["timestamp"].isoformat(),
+                "status": snapshot["status"],
+                "latency": snapshot.get("latency"),
+                "packet_loss": snapshot.get("packet_loss"),
+                "connection_quality": snapshot.get("connection_quality"),
+                "ip": snapshot.get("ip"),
+            }
+            for snapshot in history
+        ]
+
+    def get_device_activities(
+        self, device_name: str, limit: int = 50
+    ) -> List[NetworkActivity]:
+        """
+        Get activity log entries for a specific device
+        """
+        device_activities = [
+            activity for activity in self.activity_log if activity.device == device_name
+        ]
+
+        if limit:
+            device_activities = device_activities[:limit]
+
+        return device_activities
 
     def get_diagnostics(self) -> Dict[str, Any]:
         """

--- a/api-service/app/services/network_monitor.py
+++ b/api-service/app/services/network_monitor.py
@@ -510,7 +510,9 @@ class NetworkMonitorService:
                         import asyncio
 
                         asyncio.create_task(
-                            websocket_manager.broadcast_alert(alert.dict())
+                            websocket_manager.broadcast_alert(
+                                alert.model_dump(mode="json")
+                            )
                         )
 
                     # Track device info
@@ -579,7 +581,7 @@ class NetworkMonitorService:
                 {
                     "timestamp": datetime.now(),
                     "device_count": len(devices),
-                    "devices": [d.dict() for d in devices],
+                    "devices": [d.model_dump(mode="json") for d in devices],
                 }
             )
 
@@ -649,7 +651,7 @@ class NetworkMonitorService:
             self.stats_history.append(
                 {
                     "timestamp": datetime.now(),
-                    "stats": stats.dict(),
+                    "stats": stats.model_dump(mode="json"),
                 }
             )
 

--- a/components/DeviceHistoryChart.vue
+++ b/components/DeviceHistoryChart.vue
@@ -1,0 +1,194 @@
+<template>
+  <div class="w-full h-64">
+    <canvas ref="chartCanvas"></canvas>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { Chart, registerables } from 'chart.js'
+
+Chart.register(...registerables)
+
+interface HistorySnapshot {
+  timestamp: string
+  latency: number | null
+  packet_loss: number | null
+  connection_quality: string | null
+  status: string
+}
+
+interface Props {
+  history: HistorySnapshot[]
+}
+
+const props = defineProps<Props>()
+
+const chartCanvas = ref<HTMLCanvasElement | null>(null)
+let chartInstance: Chart | null = null
+
+const createChart = () => {
+  if (!chartCanvas.value || !props.history.length) return
+
+  // Destroy existing chart
+  if (chartInstance) {
+    chartInstance.destroy()
+  }
+
+  const ctx = chartCanvas.value.getContext('2d')
+  if (!ctx) return
+
+  // Prepare data
+  const labels = props.history.map(h => {
+    const date = new Date(h.timestamp)
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  })
+
+  const latencyData = props.history.map(h => h.latency)
+  const packetLossData = props.history.map(h => h.packet_loss)
+
+  chartInstance = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Latency (ms)',
+          data: latencyData,
+          borderColor: '#00e5ff',
+          backgroundColor: 'rgba(0, 229, 255, 0.1)',
+          borderWidth: 2,
+          tension: 0.4,
+          yAxisID: 'y',
+          pointRadius: 3,
+          pointHoverRadius: 5,
+        },
+        {
+          label: 'Packet Loss (%)',
+          data: packetLossData,
+          borderColor: '#cd7f32',
+          backgroundColor: 'rgba(205, 127, 50, 0.1)',
+          borderWidth: 2,
+          tension: 0.4,
+          yAxisID: 'y1',
+          pointRadius: 3,
+          pointHoverRadius: 5,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: 'index',
+        intersect: false,
+      },
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top',
+          labels: {
+            color: '#e5e7eb',
+            font: {
+              family: 'Orbitron',
+              size: 12,
+            },
+            usePointStyle: true,
+            padding: 15,
+          },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(17, 24, 39, 0.95)',
+          titleColor: '#00e5ff',
+          bodyColor: '#e5e7eb',
+          borderColor: '#00e5ff',
+          borderWidth: 1,
+          padding: 12,
+          titleFont: {
+            family: 'Orbitron',
+            size: 13,
+          },
+          bodyFont: {
+            family: 'Monospace',
+            size: 12,
+          },
+        },
+      },
+      scales: {
+        x: {
+          grid: {
+            color: 'rgba(0, 229, 255, 0.1)',
+            drawBorder: false,
+          },
+          ticks: {
+            color: '#9ca3af',
+            font: {
+              family: 'Monospace',
+              size: 10,
+            },
+            maxRotation: 45,
+            minRotation: 0,
+          },
+        },
+        y: {
+          type: 'linear',
+          display: true,
+          position: 'left',
+          title: {
+            display: true,
+            text: 'Latency (ms)',
+            color: '#00e5ff',
+            font: {
+              family: 'Orbitron',
+              size: 11,
+            },
+          },
+          grid: {
+            color: 'rgba(0, 229, 255, 0.1)',
+            drawBorder: false,
+          },
+          ticks: {
+            color: '#00e5ff',
+            font: {
+              family: 'Monospace',
+              size: 10,
+            },
+          },
+        },
+        y1: {
+          type: 'linear',
+          display: true,
+          position: 'right',
+          title: {
+            display: true,
+            text: 'Packet Loss (%)',
+            color: '#cd7f32',
+            font: {
+              family: 'Orbitron',
+              size: 11,
+            },
+          },
+          grid: {
+            drawOnChartArea: false,
+          },
+          ticks: {
+            color: '#cd7f32',
+            font: {
+              family: 'Monospace',
+              size: 10,
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+onMounted(() => {
+  createChart()
+})
+
+watch(() => props.history, () => {
+  createChart()
+}, { deep: true })
+</script>

--- a/components/DeviceList.vue
+++ b/components/DeviceList.vue
@@ -4,10 +4,11 @@
       Connected Devices
     </h3>
     <div class="space-y-3 max-h-96 overflow-y-auto custom-scrollbar">
-      <div
+      <NuxtLink
         v-for="device in devices"
         :key="device.id"
-        class="p-3 glass-panel rounded-lg hover:border-aether-cyan/40 transition-all duration-300 border border-aether-cyan/10"
+        :to="`/devices/${device.id}`"
+        class="block p-3 glass-panel rounded-lg hover:border-aether-cyan/40 transition-all duration-300 border border-aether-cyan/10 cursor-pointer hover:scale-[1.02]"
       >
         <div class="flex items-center justify-between mb-2">
           <div class="flex items-center space-x-3 flex-1">
@@ -56,7 +57,7 @@
             <span>{{ device.total_connections }} connections</span>
           </span>
         </div>
-      </div>
+      </NuxtLink>
     </div>
   </div>
 </template>

--- a/pages/devices/[id].vue
+++ b/pages/devices/[id].vue
@@ -1,138 +1,115 @@
 <template>
-  <div class="container mx-auto px-4 py-8">
-    <!-- Back button -->
-    <NuxtLink
-      to="/"
-      class="inline-flex items-center space-x-2 text-aether-cyan hover:text-aether-cyan-light mb-6 transition-colors"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-5 w-5"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M15 19l-7-7 7-7"
-        />
-      </svg>
-      <span class="font-orbitron">Back to Dashboard</span>
-    </NuxtLink>
+    <div class="container mx-auto px-4 py-8">
+        <!-- Back button -->
+        <NuxtLink to="/"
+            class="inline-flex items-center space-x-2 text-aether-cyan hover:text-aether-cyan-light mb-6 transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+            </svg>
+            <span class="font-orbitron">Back to Dashboard</span>
+        </NuxtLink>
 
-    <!-- Loading state -->
-    <div
-      v-if="loading"
-      class="flex items-center justify-center py-20"
-    >
-      <div class="text-aether-cyan text-xl font-orbitron">Loading device data...</div>
+        <!-- Loading state -->
+        <div v-if="loading" class="flex items-center justify-center py-20">
+            <div class="text-aether-cyan text-xl font-orbitron">Loading device data...</div>
+        </div>
+
+        <!-- Error state -->
+        <div v-else-if="error" class="glass-panel rounded-lg p-8 border-2 border-red-500/40 text-center">
+            <h2 class="text-2xl font-bold text-red-500 mb-2">Error</h2>
+            <p class="text-gray-300">{{ error }}</p>
+        </div>
+
+        <!-- Device details -->
+        <div v-else-if="device">
+            <!-- Device header -->
+            <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/40 mb-6">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center space-x-4">
+                        <div class="text-5xl">
+                            {{ getDeviceIcon(device.type) }}
+                        </div>
+                        <div>
+                            <h1 class="text-3xl font-bold font-merriweather text-aether-cyan cyan-glow">
+                                {{ device.name }}
+                            </h1>
+                            <p class="text-gray-400 font-mono text-sm mt-1">
+                                {{ device.ip }} • {{ device.mac }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="text-right">
+                        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium"
+                            :class="device.status === 'online' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'">
+                            {{ device.status }}
+                        </span>
+                    </div>
+                </div>
+
+                <!-- Device metrics -->
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
+                    <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+                        <div class="text-gray-400 text-xs font-orbitron mb-1">Latency</div>
+                        <div class="text-white text-lg font-bold">
+                            {{ device.latency !== null ? `${device.latency.toFixed(1)} ms` : 'N/A' }}
+                        </div>
+                    </div>
+                    <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+                        <div class="text-gray-400 text-xs font-orbitron mb-1">Packet Loss</div>
+                        <div class="text-white text-lg font-bold">
+                            {{ device.packet_loss !== null ? `${device.packet_loss.toFixed(1)}%` : 'N/A' }}
+                        </div>
+                    </div>
+                    <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+                        <div class="text-gray-400 text-xs font-orbitron mb-1">Quality</div>
+                        <div class="text-white text-lg font-bold capitalize">
+                            {{ device.connection_quality || 'Unknown' }}
+                        </div>
+                    </div>
+                    <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+                        <div class="text-gray-400 text-xs font-orbitron mb-1">Connections</div>
+                        <div class="text-white text-lg font-bold">
+                            {{ device.total_connections || 1 }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- History chart -->
+            <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20 mb-6">
+                <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
+                    Connection History
+                </h2>
+                <DeviceHistoryChart v-if="history.length > 0" :history="history" />
+                <div v-else class="text-center text-gray-400 py-8">
+                    No historical data available yet
+                </div>
+            </div>
+
+            <!-- Activity log -->
+            <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20">
+                <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
+                    Recent Activity
+                </h2>
+                <div v-if="activities.length > 0" class="space-y-3 max-h-96 overflow-y-auto custom-scrollbar">
+                    <div v-for="activity in activities" :key="activity.id"
+                        class="flex items-start space-x-3 p-3 glass-panel rounded-lg border border-aether-cyan/10 hover:border-aether-cyan/30 transition-all">
+                        <div class="flex-shrink-0 w-2 h-2 mt-2 bg-aether-cyan rounded-full pulse-animation"></div>
+                        <div class="flex-1">
+                            <p class="text-white font-orbitron">
+                                {{ activity.action }}
+                            </p>
+                            <p class="text-gray-400 text-sm font-mono">{{ formatTime(activity.timestamp) }}</p>
+                        </div>
+                    </div>
+                </div>
+                <div v-else class="text-center text-gray-400 py-8">
+                    No recent activity
+                </div>
+            </div>
+        </div>
     </div>
-
-    <!-- Error state -->
-    <div
-      v-else-if="error"
-      class="glass-panel rounded-lg p-8 border-2 border-red-500/40 text-center"
-    >
-      <h2 class="text-2xl font-bold text-red-500 mb-2">Error</h2>
-      <p class="text-gray-300">{{ error }}</p>
-    </div>
-
-    <!-- Device details -->
-    <div v-else-if="device">
-      <!-- Device header -->
-      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/40 mb-6">
-        <div class="flex items-center justify-between">
-          <div class="flex items-center space-x-4">
-            <div class="text-5xl">
-              {{ getDeviceIcon(device.type) }}
-            </div>
-            <div>
-              <h1 class="text-3xl font-bold font-merriweather text-aether-cyan cyan-glow">
-                {{ device.name }}
-              </h1>
-              <p class="text-gray-400 font-mono text-sm mt-1">
-                {{ device.ip }} • {{ device.mac }}
-              </p>
-            </div>
-          </div>
-          <div class="text-right">
-            <span
-              class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium"
-              :class="device.status === 'online' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'"
-            >
-              {{ device.status }}
-            </span>
-          </div>
-        </div>
-
-        <!-- Device metrics -->
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
-          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
-            <div class="text-gray-400 text-xs font-orbitron mb-1">Latency</div>
-            <div class="text-white text-lg font-bold">
-              {{ device.latency !== null ? `${device.latency.toFixed(1)} ms` : 'N/A' }}
-            </div>
-          </div>
-          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
-            <div class="text-gray-400 text-xs font-orbitron mb-1">Packet Loss</div>
-            <div class="text-white text-lg font-bold">
-              {{ device.packet_loss !== null ? `${device.packet_loss.toFixed(1)}%` : 'N/A' }}
-            </div>
-          </div>
-          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
-            <div class="text-gray-400 text-xs font-orbitron mb-1">Quality</div>
-            <div class="text-white text-lg font-bold capitalize">
-              {{ device.connection_quality || 'Unknown' }}
-            </div>
-          </div>
-          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
-            <div class="text-gray-400 text-xs font-orbitron mb-1">Connections</div>
-            <div class="text-white text-lg font-bold">
-              {{ device.total_connections || 1 }}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- History chart -->
-      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20 mb-6">
-        <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
-          Connection History
-        </h2>
-        <DeviceHistoryChart v-if="history.length > 0" :history="history" />
-        <div v-else class="text-center text-gray-400 py-8">
-          No historical data available yet
-        </div>
-      </div>
-
-      <!-- Activity log -->
-      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20">
-        <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
-          Recent Activity
-        </h2>
-        <div v-if="activities.length > 0" class="space-y-3 max-h-96 overflow-y-auto custom-scrollbar">
-          <div
-            v-for="activity in activities"
-            :key="activity.id"
-            class="flex items-start space-x-3 p-3 glass-panel rounded-lg border border-aether-cyan/10 hover:border-aether-cyan/30 transition-all"
-          >
-            <div class="flex-shrink-0 w-2 h-2 mt-2 bg-aether-cyan rounded-full pulse-animation"></div>
-            <div class="flex-1">
-              <p class="text-white font-orbitron">
-                {{ activity.action }}
-              </p>
-              <p class="text-gray-400 text-sm font-mono">{{ formatTime(activity.timestamp) }}</p>
-            </div>
-          </div>
-        </div>
-        <div v-else class="text-center text-gray-400 py-8">
-          No recent activity
-        </div>
-      </div>
-    </div>
-  </div>
 </template>
 
 <script setup lang="ts">
@@ -141,7 +118,7 @@ import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const config = useRuntimeConfig()
-const apiBase = config.public.apiBase || 'http://localhost:8000'
+const apiBase = config.public.apiBase || 'http://localhost:8001'
 
 const deviceId = route.params.id as string
 
@@ -152,71 +129,71 @@ const loading = ref(true)
 const error = ref('')
 
 const fetchDeviceData = async () => {
-  try {
-    loading.value = true
-    error.value = ''
-
-    // Fetch device details
-    const deviceData = await $fetch(`${apiBase}/api/devices/${deviceId}`)
-    device.value = deviceData
-
-    // Fetch device history
     try {
-      const historyData = await $fetch(`${apiBase}/api/devices/${deviceId}/history?limit=50`)
-      history.value = historyData.history || []
-    } catch (e) {
-      console.warn('No history available for device')
-      history.value = []
-    }
+        loading.value = true
+        error.value = ''
 
-    // Fetch device activities
-    try {
-      const activitiesData = await $fetch(`${apiBase}/api/devices/${deviceId}/activities?limit=20`)
-      activities.value = activitiesData || []
-    } catch (e) {
-      console.warn('No activities available for device')
-      activities.value = []
+        // Fetch device details
+        const deviceData = await $fetch(`${apiBase}/api/devices/${deviceId}`)
+        device.value = deviceData
+
+        // Fetch device history
+        try {
+            const historyData = await $fetch(`${apiBase}/api/devices/${deviceId}/history?limit=50`)
+            history.value = historyData.history || []
+        } catch (e) {
+            console.warn('No history available for device')
+            history.value = []
+        }
+
+        // Fetch device activities
+        try {
+            const activitiesData = await $fetch(`${apiBase}/api/devices/${deviceId}/activities?limit=20`)
+            activities.value = activitiesData || []
+        } catch (e) {
+            console.warn('No activities available for device')
+            activities.value = []
+        }
+    } catch (e: any) {
+        error.value = e.message || 'Failed to load device data'
+    } finally {
+        loading.value = false
     }
-  } catch (e: any) {
-    error.value = e.message || 'Failed to load device data'
-  } finally {
-    loading.value = false
-  }
 }
 
 const getDeviceIcon = (type: string): string => {
-  const icons: Record<string, string> = {
-    phone: '📱',
-    mobile: '📱',
-    laptop: '💻',
-    computer: '🖥️',
-    desktop: '🖥️',
-    tablet: '📱',
-    tv: '📺',
-    speaker: '🔊',
-    iot: '🌐',
-    router: '📡',
-    default: '📟'
-  }
-  return icons[type] || icons.default
+    const icons: Record<string, string> = {
+        phone: '📱',
+        mobile: '📱',
+        laptop: '💻',
+        computer: '🖥️',
+        desktop: '🖥️',
+        tablet: '📱',
+        tv: '📺',
+        speaker: '🔊',
+        iot: '🌐',
+        router: '📡',
+        default: '📟'
+    }
+    return icons[type] || icons.default
 }
 
 const formatTime = (timestamp: Date | string): string => {
-  const now = new Date()
-  const diff = now.getTime() - new Date(timestamp).getTime()
-  const minutes = Math.floor(diff / 60000)
-  
-  if (minutes < 1) return 'Just now'
-  if (minutes < 60) return `${minutes}m ago`
-  
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
+    const now = new Date()
+    const diff = now.getTime() - new Date(timestamp).getTime()
+    const minutes = Math.floor(diff / 60000)
+
+    if (minutes < 1) return 'Just now'
+    if (minutes < 60) return `${minutes}m ago`
+
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+
+    const days = Math.floor(hours / 24)
+    return `${days}d ago`
 }
 
 onMounted(() => {
-  fetchDeviceData()
+    fetchDeviceData()
 })
 </script>

--- a/pages/devices/[id].vue
+++ b/pages/devices/[id].vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <!-- Back button -->
+    <NuxtLink
+      to="/"
+      class="inline-flex items-center space-x-2 text-aether-cyan hover:text-aether-cyan-light mb-6 transition-colors"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
+      </svg>
+      <span class="font-orbitron">Back to Dashboard</span>
+    </NuxtLink>
+
+    <!-- Loading state -->
+    <div
+      v-if="loading"
+      class="flex items-center justify-center py-20"
+    >
+      <div class="text-aether-cyan text-xl font-orbitron">Loading device data...</div>
+    </div>
+
+    <!-- Error state -->
+    <div
+      v-else-if="error"
+      class="glass-panel rounded-lg p-8 border-2 border-red-500/40 text-center"
+    >
+      <h2 class="text-2xl font-bold text-red-500 mb-2">Error</h2>
+      <p class="text-gray-300">{{ error }}</p>
+    </div>
+
+    <!-- Device details -->
+    <div v-else-if="device">
+      <!-- Device header -->
+      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/40 mb-6">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center space-x-4">
+            <div class="text-5xl">
+              {{ getDeviceIcon(device.type) }}
+            </div>
+            <div>
+              <h1 class="text-3xl font-bold font-merriweather text-aether-cyan cyan-glow">
+                {{ device.name }}
+              </h1>
+              <p class="text-gray-400 font-mono text-sm mt-1">
+                {{ device.ip }} • {{ device.mac }}
+              </p>
+            </div>
+          </div>
+          <div class="text-right">
+            <span
+              class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium"
+              :class="device.status === 'online' ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'"
+            >
+              {{ device.status }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Device metrics -->
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
+          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+            <div class="text-gray-400 text-xs font-orbitron mb-1">Latency</div>
+            <div class="text-white text-lg font-bold">
+              {{ device.latency !== null ? `${device.latency.toFixed(1)} ms` : 'N/A' }}
+            </div>
+          </div>
+          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+            <div class="text-gray-400 text-xs font-orbitron mb-1">Packet Loss</div>
+            <div class="text-white text-lg font-bold">
+              {{ device.packet_loss !== null ? `${device.packet_loss.toFixed(1)}%` : 'N/A' }}
+            </div>
+          </div>
+          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+            <div class="text-gray-400 text-xs font-orbitron mb-1">Quality</div>
+            <div class="text-white text-lg font-bold capitalize">
+              {{ device.connection_quality || 'Unknown' }}
+            </div>
+          </div>
+          <div class="glass-panel rounded p-3 border border-aether-cyan/20">
+            <div class="text-gray-400 text-xs font-orbitron mb-1">Connections</div>
+            <div class="text-white text-lg font-bold">
+              {{ device.total_connections || 1 }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- History chart -->
+      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20 mb-6">
+        <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
+          Connection History
+        </h2>
+        <DeviceHistoryChart v-if="history.length > 0" :history="history" />
+        <div v-else class="text-center text-gray-400 py-8">
+          No historical data available yet
+        </div>
+      </div>
+
+      <!-- Activity log -->
+      <div class="glass-panel rounded-lg p-6 border-2 border-aether-cyan/20">
+        <h2 class="text-2xl font-bold font-merriweather text-aether-cyan mb-4">
+          Recent Activity
+        </h2>
+        <div v-if="activities.length > 0" class="space-y-3 max-h-96 overflow-y-auto custom-scrollbar">
+          <div
+            v-for="activity in activities"
+            :key="activity.id"
+            class="flex items-start space-x-3 p-3 glass-panel rounded-lg border border-aether-cyan/10 hover:border-aether-cyan/30 transition-all"
+          >
+            <div class="flex-shrink-0 w-2 h-2 mt-2 bg-aether-cyan rounded-full pulse-animation"></div>
+            <div class="flex-1">
+              <p class="text-white font-orbitron">
+                {{ activity.action }}
+              </p>
+              <p class="text-gray-400 text-sm font-mono">{{ formatTime(activity.timestamp) }}</p>
+            </div>
+          </div>
+        </div>
+        <div v-else class="text-center text-gray-400 py-8">
+          No recent activity
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase || 'http://localhost:8000'
+
+const deviceId = route.params.id as string
+
+const device = ref<any>(null)
+const history = ref<any[]>([])
+const activities = ref<any[]>([])
+const loading = ref(true)
+const error = ref('')
+
+const fetchDeviceData = async () => {
+  try {
+    loading.value = true
+    error.value = ''
+
+    // Fetch device details
+    const deviceData = await $fetch(`${apiBase}/api/devices/${deviceId}`)
+    device.value = deviceData
+
+    // Fetch device history
+    try {
+      const historyData = await $fetch(`${apiBase}/api/devices/${deviceId}/history?limit=50`)
+      history.value = historyData.history || []
+    } catch (e) {
+      console.warn('No history available for device')
+      history.value = []
+    }
+
+    // Fetch device activities
+    try {
+      const activitiesData = await $fetch(`${apiBase}/api/devices/${deviceId}/activities?limit=20`)
+      activities.value = activitiesData || []
+    } catch (e) {
+      console.warn('No activities available for device')
+      activities.value = []
+    }
+  } catch (e: any) {
+    error.value = e.message || 'Failed to load device data'
+  } finally {
+    loading.value = false
+  }
+}
+
+const getDeviceIcon = (type: string): string => {
+  const icons: Record<string, string> = {
+    phone: '📱',
+    mobile: '📱',
+    laptop: '💻',
+    computer: '🖥️',
+    desktop: '🖥️',
+    tablet: '📱',
+    tv: '📺',
+    speaker: '🔊',
+    iot: '🌐',
+    router: '📡',
+    default: '📟'
+  }
+  return icons[type] || icons.default
+}
+
+const formatTime = (timestamp: Date | string): string => {
+  const now = new Date()
+  const diff = now.getTime() - new Date(timestamp).getTime()
+  const minutes = Math.floor(diff / 60000)
+  
+  if (minutes < 1) return 'Just now'
+  if (minutes < 60) return `${minutes}m ago`
+  
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+onMounted(() => {
+  fetchDeviceData()
+})
+</script>


### PR DESCRIPTION
## Description
Implements Issue #17 - Device Detail Pages

## Features Added
- **Device History Tracking**: Track up to 100 historical snapshots per device (latency, packet loss, connection quality)
- **Device Detail Pages**: Navigate to individual device pages showing detailed metrics and trends
- **Historical Data Visualization**: Chart.js dual-axis chart displaying latency and packet loss over time
- **Device-Specific Activity Log**: Filtered activity log showing events for the selected device
- **API Endpoints**:
  - `GET /api/devices/{id}/history` - Returns historical data for a device
  - `GET /api/devices/{id}/activities` - Returns device-specific activity log

## Technical Changes
- Added in-memory device history tracking with deque (100 snapshots per device)
- Created `pages/devices/[id].vue` with Nuxt dynamic routing
- Created `DeviceHistoryChart.vue` component with Chart.js
- Made device cards clickable with NuxtLink navigation
- Fixed datetime serialization bug (.dict() → .model_dump(mode='json'))
- Updated CORS to allow localhost:3001 for frontend compatibility
- Added WebSocket connection debugging logs

## Testing
- ✅ Tested with real network data (23+ devices discovered)
- ✅ Device history endpoint returns data (tested with gateway device)
- ✅ WebSocket connection working with proper configuration
- ✅ Frontend displaying real devices with navigation

Closes #17